### PR TITLE
Fixed Syntax Error in Code Example for visual-style-guide.md 

### DIFF
--- a/contributing/visual-style-guide.md
+++ b/contributing/visual-style-guide.md
@@ -219,7 +219,7 @@ h3 {
 }
 
 p {
-  1.125rem;
+  font-size: 1.125rem;
 }
 
 .label {


### PR DESCRIPTION
The paragraph selector was missing the property key in its definition. 