### PR TITLE
Add Community Governance Poll for WBTC DC and Risk Premium Adjustment

### DIFF
--- a/governance/polls/Adjust the WBTC Debt Ceiling and Risk Premium - June 29, 2020
+++ b/governance/polls/Adjust the WBTC Debt Ceiling and Risk Premium - June 29, 2020
@@ -8,7 +8,7 @@ options:
    1: Yes
    2: No
 ---
-# Poll: Adjust the WBTC Debt Ceiling - June 29, 2020
+# Poll: Adjust the WBTC Debt Ceiling and Risk Premium - June 29, 2020
 
 The Maker Governance Community has placed a Governance Poll into the [voting system](https://vote.makerdao.com/polling) which the community can use to increase the WBTC Debt Ceiling from 10m to 20m. And to increase the WBTC Risk Premium from 1% to 2%.
 
@@ -20,7 +20,7 @@ Additional context was presented in a [Signal Request](https://forum.makerdao.co
 
 ## Next Steps
 
-* On the Friday following the conclusion of the poll, there will be an Executive Vote asking MKR token holders if they support or reject the change proposed by this Governance Poll.
+On the Friday following the conclusion of the poll, there will be an Executive Vote asking MKR token holders if they support or reject the change proposed by this Governance Poll.
 
 ---
 

--- a/governance/polls/Adjust the WBTC Debt Ceiling and Risk Premium - June 29, 2020
+++ b/governance/polls/Adjust the WBTC Debt Ceiling and Risk Premium - June 29, 2020
@@ -1,0 +1,35 @@
+---
+title: Adjust the WBTC Debt Ceiling and Risk Premium - June 29, 2020
+summary: Signal your support for increasing the WBTC Debt Ceiling from 10m to 20m. And increasing the WBTC Risk Premium from 1% to 2%.
+discussion_link: https://forum.makerdao.com/t/2824
+vote_type: Plurality Voting
+options:
+   0: Abstain
+   1: Yes
+   2: No
+---
+# Poll: Adjust the WBTC Debt Ceiling - June 29, 2020
+
+The Maker Governance Community has placed a Governance Poll into the [voting system](https://vote.makerdao.com/polling) which the community can use to increase the WBTC Debt Ceiling from 10m to 20m. And to increase the WBTC Risk Premium from 1% to 2%.
+
+This Governance Poll ([FAQ](https://community-development.makerdao.com/governance/governance#is-there-more-than-one-type-of-vote)) will be active for three days beginning on Monday, June 29 at 5 PM UTC, the results of which may inform an Executive Vote ([FAQ](https://community-development.makerdao.com/governance/governance#what-is-continuous-approval-voting)) which will go live on Friday, July 3, at 5 PM UTC.
+
+## Review
+
+Additional context was presented in a [Signal Request](https://forum.makerdao.com/t/2824) on June 13th, 2020. Please review to inform your position before voting.
+
+## Next Steps
+
+* On the Friday following the conclusion of the poll, there will be an Executive Vote asking MKR token holders if they support or reject the change proposed by this Governance Poll.
+
+---
+
+## Resources
+
+Additional information about the Governance process can be found in the [Governance Risk Framework: Governing MakerDAO](https://community-development.makerdao.com/governance/governance-risk-framework)
+
+Demos, help and instructional material for the Governance Dashboard can be found at [Awesome MakerDAO](https://awesome.makerdao.com/#voting).
+
+To participate in future Governance calls, please [join us](https://community-development.makerdao.com/governance/governance-and-risk-meetings) every Thursday at 16:00 UTC.
+
+To add current and upcoming votes to your calendar, please see the [MakerDAO Public Events Calendar](https://calendar.google.com/calendar/embed?src=makerdao.com_3efhm2ghipksegl009ktniomdk%40group.calendar.google.com&ctz=America%2FLos_Angeles)

--- a/governance/polls/Adjust the WBTC Debt Ceiling and Risk Premium - June 29, 2020
+++ b/governance/polls/Adjust the WBTC Debt Ceiling and Risk Premium - June 29, 2020
@@ -10,7 +10,7 @@ options:
 ---
 # Poll: Adjust the WBTC Debt Ceiling and Risk Premium - June 29, 2020
 
-The Maker Governance Community has placed a Governance Poll into the [voting system](https://vote.makerdao.com/polling) which the community can use to increase the WBTC Debt Ceiling from 10m to 20m. And to increase the WBTC Risk Premium from 1% to 2%.
+The Governance Facilitators have placed a Governance Poll into the [voting system](https://vote.makerdao.com/polling) on behalf of the Maker Governance Community. The community can use this poll express support or opposition to increasing the WBTC Debt Ceiling from 10m to 20m, and increasing the WBTC Risk Premium from 1% to 2%.
 
 This Governance Poll ([FAQ](https://community-development.makerdao.com/governance/governance#is-there-more-than-one-type-of-vote)) will be active for three days beginning on Monday, June 29 at 5 PM UTC, the results of which may inform an Executive Vote ([FAQ](https://community-development.makerdao.com/governance/governance#what-is-continuous-approval-voting)) which will go live on Friday, July 3, at 5 PM UTC.
 


### PR DESCRIPTION
This poll will go live June 29, 2020.