### PR TITLE
Add Github Action to push to IPFS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,20 @@
+name: IPFS
+
+on:
+  push:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Upload to IPFS
+      uses: aquiladev/ipfs-action@v0.1.3
+      with:
+        # Directory path to upload
+        path: governance/
+        # Level of verbosity
+        verbose: true


### PR DESCRIPTION
- on pushes to master, write governance/polls directory to IPFS

Example build:
<img width="948" alt="Screen Shot 2020-06-26 at 3 49 11 PM" src="https://user-images.githubusercontent.com/7875345/85900041-ba94ac00-b7c4-11ea-9eea-e14bbca3f413.png">

Result available at https://ipfs.io/ipfs/QmcqRPbXBxcq8Cw4u3h8zCGcjxKaEaBJ2DXf7rUMjqcA1X
