### PR TITLE
Create poll meta dir, add initial poll category list

### DIFF
--- a/governance/polls/meta/categories.json
+++ b/governance/polls/meta/categories.json
@@ -1,0 +1,9 @@
+[
+  "System Risk Variables",
+  "Protocol Changes",
+  "Procedural Changes",
+  "MIPs",
+  "Oracles",
+  "Collateral Onboarding",
+  "Other"
+]


### PR DESCRIPTION
Creates an initial list of poll categories. This can be used 1) to fill in the [poll creator app](https://vote.makerdao.com/polling/create) category dropdown<sup>1</sup> and 2) to validate future poll documents. Added here rather than in the portal itself so it can be more legibly changed by community/ gov facilitator. 


The actual contents of list I've copied over from a draft doc somewhere else, so feel free to suggest obvious changes. Though since (afaik) we're planning to categorize previous polls, my feeling is that we shouldn't settle on anything until that resolves – but, neither should we be too worried about finding an exhaustive list, adding categories after they've been merged shouldn't be disruptive really. 


Also, this PR creates a `meta/` folder in `polls/` which can be used as a source of truth for polling metadata. Use cases include:
* references to be used in poll document creation and validation (eg categories, valid vote types, required fields, etc)
* a place to store additional data for existing polls without invalidating their hash (eg a mapping of `poll` to `category` that adds categories to previous polls that don't already specify one)

---

**1** ![poll-category-picker](https://user-images.githubusercontent.com/24902242/86829161-159a8e80-c062-11ea-8b45-fa335e67412c.gif)