### PR TITLE
Voter onboarding link repair

### DIFF
--- a/onboarding/voter-onboarding.md
+++ b/onboarding/voter-onboarding.md
@@ -40,7 +40,7 @@ A collection of sources and materials useful for MKR voters:
 ### Essential:
 
 - [Governance Forum](https://forum.makerdao.com/c/governance)
-- [Governance and Risk Meeting: Audio](https://soundcloud.com/makerdao/sets/governance-calls) | [Video](https://www.youtube.com/playlist?list=PLLzkWCj8ywWNq5-90-Id6VPSsrk4OWVan) | [Transcripts](https://github.com/makerdao/community/blob/master/governance/governance-and-risk-meetings/transcripts) | [Summaries](https://github.com/makerdao/community/blob/master/governance/governance-and-risk-meetings/transcripts)
+- [Governance and Risk Meeting: Audio](https://soundcloud.com/makerdao/sets/governance-calls) | [Video](https://www.youtube.com/playlist?list=PLLzkWCj8ywWNq5-90-Id6VPSsrk4OWVan) | [Transcripts](https://github.com/makerdao/community/blob/master/governance/governance-and-risk-meetings/transcripts) | [Summaries](https://community-development.makerdao.com/governance/governance-and-risk-meetings/summaries)
 - [Ratified Foundation Proposal](https://medium.com/makerdao/foundation-proposal-v2-f10d8ee5fe8c)
 - [Voting Tutorial Video](https://youtu.be/wP7DedWcEmg?list=PLLzkWCj8ywWP6yCPPm1IRKysNsrzg3LQ6)
 


### PR DESCRIPTION
This repairs the "Summaries" link for the governance and risk meeting. 🙂