### PR TITLE
Type Refactor, Mobile Nav Fixes, Blog Mobile Nav Support, Blog Recommendations

### DIFF
--- a/blogPosts/en/blog/Community/HelloWorld copy.mdx
+++ b/blogPosts/en/blog/Community/HelloWorld copy.mdx
@@ -1,8 +1,7 @@
 ---
 title: "Hello from the Blogosphere"
 authors: 'MaximumCrash'
-type: 'Governance'
-date: 1990-01-14 
+date: 2021-01-14
 ---
 
 ![Image](https://rejontaylor.com/Images/Projects/beckerderby.jpg)

--- a/blogPosts/en/blog/Editorial/HelloWorld copy 10.mdx
+++ b/blogPosts/en/blog/Editorial/HelloWorld copy 10.mdx
@@ -1,8 +1,7 @@
 ---
 title: "Hello from the Blogosphere"
 authors: 'MaximumCrash'
-type: 'Governance'
-date: 2020-11-14
+date: 2020-01-14
 ---
 
 ![Image](https://rejontaylor.com/Images/Projects/beckerderby.jpg)

--- a/blogPosts/en/blog/Editorial/HelloWorld copy 11.mdx
+++ b/blogPosts/en/blog/Editorial/HelloWorld copy 11.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Hello from the Blogosphere"
 authors: 'MaximumCrash'
-type: 'Editorial'
 date: 2020-01-14
 ---
 

--- a/blogPosts/en/blog/Editorial/HelloWorld copy 12.mdx
+++ b/blogPosts/en/blog/Editorial/HelloWorld copy 12.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Hello from the Blogosphere"
 authors: 'MaximumCrash'
-type: 'Editorial'
 date: 2020-01-14
 ---
 

--- a/blogPosts/en/blog/Editorial/HelloWorld copy 13.mdx
+++ b/blogPosts/en/blog/Editorial/HelloWorld copy 13.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Hello from the Blogosphere"
 authors: 'MaximumCrash'
-type: 'Editorial'
 date: 2020-01-14
 ---
 

--- a/blogPosts/en/blog/Editorial/HelloWorld copy 14.mdx
+++ b/blogPosts/en/blog/Editorial/HelloWorld copy 14.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Hello from the Blogosphere"
 authors: 'MaximumCrash'
-type: 'Editorial'
 date: 2020-01-14
 ---
 

--- a/blogPosts/en/blog/Editorial/HelloWorld copy 15.mdx
+++ b/blogPosts/en/blog/Editorial/HelloWorld copy 15.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Hello from the Blogosphere"
 authors: 'MaximumCrash'
-type: 'Editorial'
 date: 2020-01-14
 ---
 

--- a/blogPosts/en/blog/Editorial/HelloWorld copy 4.mdx
+++ b/blogPosts/en/blog/Editorial/HelloWorld copy 4.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Hello from the Blogosphere"
 authors: 'MaximumCrash'
-type: 'Editorial'
 date: 2020-01-14
 ---
 

--- a/blogPosts/en/blog/Editorial/HelloWorld copy 5.mdx
+++ b/blogPosts/en/blog/Editorial/HelloWorld copy 5.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Hello from the Blogosphere"
 authors: 'MaximumCrash'
-type: 'Editorial'
 date: 2020-01-14
 ---
 

--- a/blogPosts/en/blog/Editorial/HelloWorld copy 6.mdx
+++ b/blogPosts/en/blog/Editorial/HelloWorld copy 6.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Hello from the Blogosphere"
 authors: 'MaximumCrash'
-type: 'Editorial'
 date: 2020-01-14
 ---
 

--- a/blogPosts/en/blog/Editorial/HelloWorld copy 7.mdx
+++ b/blogPosts/en/blog/Editorial/HelloWorld copy 7.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Hello from the Blogosphere"
 authors: 'MaximumCrash'
-type: 'Editorial'
 date: 2020-01-14
 ---
 

--- a/blogPosts/en/blog/Editorial/HelloWorld copy 8.mdx
+++ b/blogPosts/en/blog/Editorial/HelloWorld copy 8.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Hello from the Blogosphere"
 authors: 'MaximumCrash'
-type: 'Editorial'
 date: 2020-01-14
 ---
 

--- a/blogPosts/en/blog/Editorial/HelloWorld copy 9.mdx
+++ b/blogPosts/en/blog/Editorial/HelloWorld copy 9.mdx
@@ -1,7 +1,6 @@
 ---
 title: "Hello from the Blogosphere"
 authors: 'MaximumCrash'
-type: 'Editorial'
 date: 2020-01-14
 ---
 

--- a/blogPosts/en/blog/Editorial/Humans_Of_MakerDAO_01.mdx
+++ b/blogPosts/en/blog/Editorial/Humans_Of_MakerDAO_01.mdx
@@ -2,7 +2,6 @@
 title: "Humans of MakerDAO 01"
 keywords: "makerdao, dao, decentralized, dai"
 description: "Introducing the Humans of MakerDAO."
-type: Editorial
 date: 2021-01-29
 authors: "goldfarbas"
 ---

--- a/blogPosts/en/blog/Editorial/Top_5_Resources_Learning_Maker_Vaults.mdx
+++ b/blogPosts/en/blog/Editorial/Top_5_Resources_Learning_Maker_Vaults.mdx
@@ -2,7 +2,6 @@
 title: "Top 5 Resources For Learning About Maker Vaults"
 keywords: "makerdao, vault, vaults, collateral, dai, stablecoin"
 description: "Learn about Vaults where owners can deposit collateral to generate Dai."
-type: "Editorial"
 date: 2021-01-29
 authors: "goldfarbas"
 ---

--- a/blogPosts/en/blog/Governance/HelloWorld copy 2.mdx
+++ b/blogPosts/en/blog/Governance/HelloWorld copy 2.mdx
@@ -1,8 +1,7 @@
 ---
 title: "Hello from the Blogosphere"
 authors: 'MaximumCrash'
-type: 'Community'
-date: 2021-01-14
+date: 2020-11-14
 ---
 
 ![Image](https://rejontaylor.com/Images/Projects/beckerderby.jpg)

--- a/blogPosts/en/blog/Governance/HelloWorld copy 3.mdx
+++ b/blogPosts/en/blog/Governance/HelloWorld copy 3.mdx
@@ -1,8 +1,7 @@
 ---
 title: "Hello from the Blogosphere"
 authors: 'MaximumCrash'
-type: 'Editorial'
-date: 2020-01-14
+date: 1990-01-14 
 ---
 
 ![Image](https://rejontaylor.com/Images/Projects/beckerderby.jpg)

--- a/blogPosts/en/blog/Governance/HelloWorld.mdx
+++ b/blogPosts/en/blog/Governance/HelloWorld.mdx
@@ -1,7 +1,6 @@
 ---
 title: "How to Get Dai"
 authors: 'MaximumCrash'
-type: 'Governance'
 date: 2021-01-15
 ---
 

--- a/blogPosts/en/blog/Governance/HelloWorld.mdx
+++ b/blogPosts/en/blog/Governance/HelloWorld.mdx
@@ -2,6 +2,7 @@
 title: "How to Get Dai"
 authors: 'MaximumCrash'
 date: 2021-01-15
+recommend: ['/governance/HelloWorld copy 2', '/governance/HelloWorld copy 2']
 ---
 
 ![Image](https://rejontaylor.com/Images/Projects/beckerderby.jpg)

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -201,33 +201,6 @@ exports.onCreatePage = async ({ page, actions }) => {
     oldPageContext.regex =`//blogPosts/${page.path.split('/')[1]}/` //ie. /blogPosts/en
   }
 
-  //NOTE(Rejon): Check for a blog post page (not home page) and provide recommendation regex. 
-  if (page.path.includes("/blog/") && page.componentPath.includes("/blogPosts/") && oldPageContext.frontmatter !== undefined)
-  {
-    const recommandations = oldPageContext.frontmatter?.recommend;
-      if (Array.isArray(recommandations))
-      {
-        oldPageContext.recommendationRegex = `/`;
-        
-        recommandations.map((rec, index) => {
-          oldPageContext.recommendationRegex += `(/blogPosts/${page.path.split('/')[1]}/blog${rec}.mdx)`
-
-          if (index !== recommandations.length - 1)
-          {
-            oldPageContext.recommendationRegex += '|'
-          }
-          else 
-          {
-            oldPageContext.recommendationRegex += '/gm'
-          }
-        })
-      }
-      else if (typeof recommandations === 'string')
-      {
-        oldPageContext.recommendationRegex = `/(/blogPosts/${page.path.split('/')[1]}/blog${recommandations}.mdx)`;
-      }
-  }
-
   deletePage(page);
   createPage({
     ...page,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -201,6 +201,33 @@ exports.onCreatePage = async ({ page, actions }) => {
     oldPageContext.regex =`//blogPosts/${page.path.split('/')[1]}/` //ie. /blogPosts/en
   }
 
+  //NOTE(Rejon): Check for a blog post page (not home page) and provide recommendation regex. 
+  if (page.path.includes("/blog/") && page.componentPath.includes("/blogPosts/") && oldPageContext.frontmatter !== undefined)
+  {
+    const recommandations = oldPageContext.frontmatter?.recommend;
+      if (Array.isArray(recommandations))
+      {
+        oldPageContext.recommendationRegex = `/`;
+        
+        recommandations.map((rec, index) => {
+          oldPageContext.recommendationRegex += `(/blogPosts/${page.path.split('/')[1]}/blog${rec}.mdx)`
+
+          if (index !== recommandations.length - 1)
+          {
+            oldPageContext.recommendationRegex += '|'
+          }
+          else 
+          {
+            oldPageContext.recommendationRegex += '/gm'
+          }
+        })
+      }
+      else if (typeof recommandations === 'string')
+      {
+        oldPageContext.recommendationRegex = `/(/blogPosts/${page.path.split('/')[1]}/blog${recommandations}.mdx)`;
+      }
+  }
+
   deletePage(page);
   createPage({
     ...page,

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -198,7 +198,7 @@ exports.onCreatePage = async ({ page, actions }) => {
   //NOTE(Rejon): Pass a regex string variable for blog home pages so we can make sure we're getting the correct locale. 
   if (page.path.includes("/blog/") && !page.componentPath.includes("/blogPosts/"))
   {
-    oldPageContext.regex =`//blogPosts/${page.path.split('/')[1]}/`
+    oldPageContext.regex =`//blogPosts/${page.path.split('/')[1]}/` //ie. /blogPosts/en
   }
 
   deletePage(page);

--- a/src/modules/blog/BlogCard.js
+++ b/src/modules/blog/BlogCard.js
@@ -6,13 +6,14 @@ import {Link} from '@modules/navigation';
 
 
 import {BlogAuthor} from '@modules/blog'
-import {UrlConverter} from '@utils'
+import {UrlConverter, getBlogPostTypeFromPath} from '@utils'
 import { useTranslation } from "@modules/localization";
 
 const BlogCard = ({excerpt, fileAbsolutePath, frontmatter, mdxAST, isLatest}) => {
 	const { t } = useTranslation();
 
-	const {authors, date, description, title, type} = frontmatter;
+	const {authors, date, description, title} = frontmatter;
+	const type = getBlogPostTypeFromPath(fileAbsolutePath); 
 	let postImage = null; 
 	const postLink = fileAbsolutePath 
     .slice(fileAbsolutePath.indexOf("/blogPosts/") + 10, fileAbsolutePath.length)
@@ -34,7 +35,7 @@ const BlogCard = ({excerpt, fileAbsolutePath, frontmatter, mdxAST, isLatest}) =>
 
 	return (
 		<div sx={{
-			maxWidth:'286px',
+			maxWidth:['unset','unset','286px'],
 			width: '100%',
 			px: 2,
 			borderBottom: ['1px solid', 'unset', 'unset'],
@@ -61,9 +62,9 @@ const BlogCard = ({excerpt, fileAbsolutePath, frontmatter, mdxAST, isLatest}) =>
 					</Link>
 				}
 			</p>
-			{postImage && <Link to={postLink} hideExternalIcon sx={{display: 'block'}}><img src={postImage} sx={{ maxWidth: '288px', width: '100%', height: '188px', objectFit: 'cover', mb: 2,}}/></Link>}
+			{postImage && <Link to={postLink} hideExternalIcon sx={{display: 'block'}}><img src={postImage} sx={{ maxWidth: ['unset', 'unset', '288px'], width: '100%', height: '188px', objectFit: 'cover', mb: 2,}}/></Link>}
 
-			<Link sx={{mb: '26px', fontWeight: 500, fontSize: 6, color: 'text', display: 'block'}} to={postLink} hideExternalIcon> {title} </Link>
+			<Link sx={{mb: '26px', fontWeight: 500, fontSize: [6], color: 'text', display: 'block'}} to={postLink} hideExternalIcon> {title} </Link>
 
 			{(!isNil(authors) &&
 				<BlogAuthor author={authors} date={date}/>

--- a/src/modules/navigation/MobileNav.js
+++ b/src/modules/navigation/MobileNav.js
@@ -9,7 +9,7 @@ import { Link, SidenavNode } from "@modules/navigation";
 import { useTranslation } from "@modules/localization";
 import { useNavigation } from "@modules/navigation/context";
 
-const MobileNav = ({ sidenavData }) => {
+const MobileNav = ({ sidenavData, blogData }) => {
   const { headerLinks, mobileNavOpen, hideMobileMenu } = useNavigation();
   const { locale, t } = useTranslation();
   const { pathname } = useLocation();
@@ -19,9 +19,11 @@ const MobileNav = ({ sidenavData }) => {
   //AND if the sidenav for this top section has items render inside the submenu.
   //Else render the main menu
   const renderSubmenuInitial =
-    sidenavData.items[0] !== undefined &&
+    (blogData !== undefined
+    )
+    || (sidenavData.items[0] !== undefined &&
     sidenavData.items[0].slugPart === pathname.split("/")[2] &&
-    sidenavData.items[0].items.length > 0;
+    sidenavData.items[0].items.length > 0);
 
   const [showMainMenu, setShowMainMenu] = useState(
     renderSubmenuInitial === false
@@ -31,6 +33,83 @@ const MobileNav = ({ sidenavData }) => {
 
   if (!mobileNavOpen) {
     return null;
+  }
+
+  //NOTE(Rejon): This is to mimic the subnav menu link/button logic for the Blog 
+  //             since it's routing logic lives outside of the typical sidenav flow. 
+  const renderBlogButton = () => {
+    //Render the Blog link as a button that can then take us to the submenu
+    if (renderSubmenuInitial && blogData !== undefined)
+    {
+      return (
+        <Box
+          sx={{
+            py: "2vh",
+            px: [3, "30px", null],
+            textDecoration: "none",
+            color: "onBackgroundAlt",
+            position: "relative",
+            fontWeight: "500",
+            cursor: "pointer",
+            "&:hover": {
+              textDecoration: "none",
+              color: "primary",
+            },
+          }}
+          onClick={() => setShowMainMenu(false)}
+          key={`mobile-nav-header-link-blog`}
+        >
+          {t("Blog")}
+          <Icon
+            name={
+              "chevron_right"
+            }
+            size={"3.9vw"}
+            sx={{
+              position: "absolute",
+              right: 4,
+              top: "50%",
+              transform: "translateY(-50%)",
+            }}
+          />
+        </Box>
+      )
+    }
+
+    //Return normal link 
+    return(
+      <Link
+        to={`/${locale}/blog`}
+        sx={{
+          py: "2vh",
+          textDecoration: "none",
+          color: "onBackgroundAlt",
+          position: "relative",
+          fontWeight: "normal",
+          px: [3, "30px", null],
+          "&:hover": {
+            textDecoration: "none",
+          },
+        }}
+        onClick={hideMobileMenu}
+        key={`mobile-nav-header-link-blog`}
+        hideExternalIcon
+      >
+        {t('Blog')}
+        <Icon
+          name={
+            "chevron_right"
+          }
+          size={"3.9vw"}
+          sx={{
+            position: "absolute",
+            right: 4,
+            top: "50%",
+            transform: "translateY(-50%)",
+          }}
+        />
+      </Link>
+    )
   }
 
   return (
@@ -112,7 +191,7 @@ const MobileNav = ({ sidenavData }) => {
                 //destination.
                 if (
                   renderSubmenuInitial &&
-                  sidenavData.items[0] !== undefined
+                  sidenavData?.items[0] !== undefined
                 ) {
                   let urlDirs = url.replace(/\/+$/, "").split("/");
                   urlDirs = urlDirs.slice(2, urlDirs.length);
@@ -188,6 +267,7 @@ const MobileNav = ({ sidenavData }) => {
                   </Link>
                 );
               })}
+              {renderBlogButton()}
             </Flex>
 
             <Flex
@@ -311,14 +391,78 @@ const MobileNav = ({ sidenavData }) => {
                 {t("Back_To_Main_Menu")}
               </Text>
             </Flex>
-            {sidenavData && sidenavData.items[0] && (
+            {blogData !== undefined && (
+              <Box sx={{overflow: "auto", maxHeight: "80vh", pb: "10vh"}}>
+                  <Link
+                    onClick={hideMobileMenu}
+                    sx={{
+                      pb: "2vh",
+                      fontSize: ["7vw", "5vw", null],
+                      textDecoration: "none",
+                      px: [3, "30px", null],
+                      color: "primary",
+                      display: "block",
+                      mb: 3,
+                      pt: "calc(2vh + 6px)",
+                      "&:hover": {
+                        textDecoration: "none",
+                      },
+                    }}
+                    to={`/${locale}/blog/`}
+                  >
+                    {t("Blog")}
+                  </Link>
+                  <Flex
+                    sx={{
+                      flexDirection: "column",
+                      fontSize: ["5vw", "5vw", null],
+                      mb: "33px",
+                    }}
+                  >
+                  {blogData.map((section, index) => (
+                    <Link
+                      to={`/${locale}/blog?section=${section}`}
+                      sx={{
+                        py: "2vh",
+                        textDecoration: "none",
+                        color: "onBackgroundAlt",
+                        position: "relative",
+                        fontWeight: "normal",
+                        px: [3, "30px", null],
+                        "&:hover": {
+                          textDecoration: "none",
+                        },
+                      }}
+                      onClick={hideMobileMenu}
+                      key={`mobile-nav-header-link-${index}`}
+                      hideExternalIcon
+                    >
+                      {section}
+                      <Icon
+                        name={
+                          "chevron_right"
+                        }
+                        size={"3.9vw"}
+                        sx={{
+                          position: "absolute",
+                          right: 4,
+                          top: "50%",
+                          transform: "translateY(-50%)",
+                        }}
+                      />
+                    </Link>
+                  ))}
+                </Flex>
+              </Box>
+            )}
+            {sidenavData?.items[0] && blogData === undefined && (
               <Box sx={{ overflow: "auto", maxHeight: "80vh", pb: "10vh" }}>
                 {sidenavData.items[0].slugPart && (
                   <Link
                     onClick={hideMobileMenu}
                     sx={{
                       pb: "2vh",
-                      fontSize: ["5vw", "5vw", null],
+                      fontSize: ["7vw", "5vw", null],
                       textDecoration: "none",
                       px: [3, "30px", null],
                       color: "primary",
@@ -348,6 +492,7 @@ const MobileNav = ({ sidenavData }) => {
                       textDecoration: "none",
                       position: "relative",
                       px: "30px",
+                      pl: '16px',
                       "&:hover": {
                         textDecoration: "none",
                       },

--- a/src/modules/navigation/MobileNav.js
+++ b/src/modules/navigation/MobileNav.js
@@ -419,6 +419,37 @@ const MobileNav = ({ sidenavData, blogData }) => {
                       mb: "33px",
                     }}
                   >
+                  <Link
+                      to={`/${locale}/blog/`}
+                      sx={{
+                        py: "2vh",
+                        textDecoration: "none",
+                        color: "onBackgroundAlt",
+                        position: "relative",
+                        fontWeight: "normal",
+                        px: [3, "30px", null],
+                        "&:hover": {
+                          textDecoration: "none",
+                        },
+                      }}
+                      onClick={hideMobileMenu}
+                      key={`mobile-nav-header-link-blog-home`}
+                      hideExternalIcon
+                    >
+                      {t('Home')}
+                      <Icon
+                        name={
+                          "chevron_right"
+                        }
+                        size={"3.9vw"}
+                        sx={{
+                          position: "absolute",
+                          right: 4,
+                          top: "50%",
+                          transform: "translateY(-50%)",
+                        }}
+                      />
+                    </Link>
                   {blogData.map((section, index) => (
                     <Link
                       to={`/${locale}/blog?section=${section}`}
@@ -434,7 +465,7 @@ const MobileNav = ({ sidenavData, blogData }) => {
                         },
                       }}
                       onClick={hideMobileMenu}
-                      key={`mobile-nav-header-link-${index}`}
+                      key={`mobile-nav-header-link-blog-${index}`}
                       hideExternalIcon
                     >
                       {section}

--- a/src/modules/search/index.js
+++ b/src/modules/search/index.js
@@ -216,6 +216,7 @@ export default function Search({ onClick, ...otherProps }) {
           minHeight: 4,
           borderRadius: "roundish",
           overflow: "hidden",
+          pointerEvents: query.length > 0 && focus ? 'all' : 'none'
         }}
       >
         <Box

--- a/src/pages/en/blog.js
+++ b/src/pages/en/blog.js
@@ -185,6 +185,7 @@ const BlogHome = ({data}) => {
 						cursor: 'pointer',
 						transition: 'all .16s',
 						fontWeight:  400,
+						textTransform: 'capitalize',
 						'&:hover':  {
 							color: 'linkAlt'
 						}
@@ -273,7 +274,6 @@ const BlogHome = ({data}) => {
 				date(formatString: "MMMM DD, YYYY", locale: $locale)
 				description
 				authors
-				
 				}
 				mdxAST
 				id

--- a/src/utils.js
+++ b/src/utils.js
@@ -127,3 +127,25 @@ export const formatNumber = (num) => {
     .toString()
     .replace(/(\d)(?=(\d{3})+(?!\d))/g, "$1,");
 };
+
+//NOTE(Rejon): This seems extraneous, but it's so we can support getting types from the file path instead of writers having to provide type via frontmatter. 
+export const getBlogPostTypeFromPath = (path) => {
+  const pathArr = path.split('/');
+  
+  const nodeAfterBlog = pathArr[pathArr.indexOf('blog') +  1];
+
+  if (nodeAfterBlog !== undefined) //Check if node after blog is not undefined. 
+  {
+    //Check if the node after blog is a mdx/markdown file.  
+    if (nodeAfterBlog.includes('.mdx') || nodeAfterBlog.includes('.md'))
+    {
+      return null; 
+    }
+
+    return nodeAfterBlog; 
+  }
+  else 
+  {
+    return null; 
+  }
+}


### PR DESCRIPTION
<!-- If you're unsure about any question, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code. -->

### Attention (CC)

@twblack88 
@ofqwx 

## Summary of changes

- Refactored Type for blog post to be based on route/directory instead of frontmatter (see below for more) 
- Updated blog homepage logic to support new route based typing. 
- Fixed mobile nav submenu "Go to back to main menu" not functional due to mobile search result element blocking pointer events. 
- Added blog submenu support to mobile nav 
- Added blog recommendation logic to blogPost_layout.mdx (see below for more)

## Relevant Context

- Issue: #1047 
- Pull Request: #1126 

## How Has This Been Tested?

Locally

## Screenshots (if appropriate):
N/A

## Further comments

# Post Type 

Prior to this PR typing was done using frontmatter `ie. type: 'Governance'`. This isn't a bad execution, but folks won't always remember to add this and could spell it wrong accidentally leading to automagic issues. Instead I opted to update the blogPosts directory to reflect the type of articles folks could write. 

```
 blogPosts
    -en (needed for clean routes)
        -blog (needed for clean routes)
           - editorial <- Type
           - governance <- Type
           - community <- Type
           - ...other blog post pages not typed
```

This should lower the friction and make it more obvious the types that folks can write for and where they go without having to remember frontmatter. If you want to create more types, you just add a new directory in the appropriate blog directory. **NOTE: It will also show up on the blog homepage as a section filtering option and on the mobile nav submenus.**

# Recommendations

It is now possible to recommend other blog posts at the end of a blog post by providing this frontmatter:

```
---
recommend: '/governance/HelloWorld'
---
```

this will render **one** blog card with the appropriate information at the end of your blog post in the "Read More" section. 

To recommend multiple blog posts you can provide an array like so:

```
---
recommend: ['/governance/HelloWorld', '/editorial/HowAreYou']
---
```

This will render 2 blog cards and so on. 

The schema for recommendation is as follows:

recommend: String or String[]
- Must be written like a link url to the blog post without locale and blog. (ie. `/blog/en/editorial/HowAreYou` become `/editorial/HowAreYou`. 

**NOTE: It is purposefully designed that you can't provide recommendations from other locales. If this is a feature the community wants I can integrate it with ease.**

<!--- If this is a relatively large or complex change, kick off the discussion by explaining why you chose the solution you did and what alternatives you considered, etc... -->


--- 
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Content edit, File upload, content addition
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Technical Documentation Update
- [ ] Other (please describe):

## Does this introduce a breaking change?

_Breaking change is defined as_ **"A fix or feature that would cause existing functionality to change."**

- [x] Yes
- [ ] No

<!--- If this introduces a breaking change, please describe the impact and migration path for existing modules below. -->

## Checklist:

<!--- Put an `x` in the boxes that apply. -->

- [x] My code follows the code style of this project.
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added/changed necessary documentation (if appropriate)
- [ ] All new and existing tests passed.
