### PR TITLE
Update delegate profiles to Discord handles

### DIFF
--- a/governance/delegates/0x22d5294a23d49294Bf11D9db8bEda36e104ad9b3/profile.md
+++ b/governance/delegates/0x22d5294a23d49294Bf11D9db8bEda36e104ad9b3/profile.md
@@ -11,7 +11,7 @@ Name: MakerMan
 
 Forum: @MakerMan
 
-Rocketchat: @Maker_Man
+Discord: @MakerMan#6155
 
 Email: DaiMakerMan@gmail.com
 

--- a/governance/delegates/0xAF8aa6846539033Eaf0c3ca4C9C7373e370E039b/profile.md
+++ b/governance/delegates/0xAF8aa6846539033Eaf0c3ca4C9C7373e370E039b/profile.md
@@ -9,7 +9,7 @@ external_profile_url: https://forum.makerdao.com/u/elprogreso/
 
 Delegate Address: flapper.eth  
 Forum: @ElProgreso  
-Rocketchat: @ElPro  
+Discord: @ElPro#2818  
 Email (optional): ElProDAI@protonmail.com  
 Introduction Video: https://www.youtube.com/watch?v=22ut8FuGu_Q  
 Meet Your Delegate Video: https://www.youtube.com/watch?v=SVUm1Bz0U9A&t=1577s


### PR DESCRIPTION
@LongForWisdom updated delegate profiles for Elpro and MakerMan with discord handles and removed rocketchat handles. Both delegates agreed to the change being made on their behalf